### PR TITLE
ci: github action gradlew 권한 문제

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,6 +26,10 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
+
+    - name: Run chmod to make gradlew executable
+      run: chmod +x ./gradlew
+
     - name: Test with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       with:


### PR DESCRIPTION
이전의 권한 문제가 해결되지 않아 github action에 직접적으로 권한 부여를 함