### PR TITLE
미인증된 아이디로 회원가입 가능 버그

### DIFF
--- a/src/main/java/com/fanfixiv/auth/config/RedisConfig.java
+++ b/src/main/java/com/fanfixiv/auth/config/RedisConfig.java
@@ -1,6 +1,9 @@
 package com.fanfixiv.auth.config;
 
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +11,8 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories //  Redis Repository 활성화
@@ -20,15 +25,24 @@ public class RedisConfig {
   private String host;
 
   @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // timestamp 형식 안따르도록 설정
+    mapper.registerModules(new JavaTimeModule(), new Jdk8Module()); // LocalDateTime 매핑을 위해 모듈 활성화
+    return mapper;
+  }
+
+  @Bean
   public RedisConnectionFactory redisConnectionFactory() {
-    LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(host, port);
-    return lettuceConnectionFactory;
+    return new LettuceConnectionFactory(host, port);
   }
 
   @Bean
   public RedisTemplate<?, ?> redisTemplate() {
     RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
     redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
     return redisTemplate;
   }
 }

--- a/src/main/java/com/fanfixiv/auth/dto/redis/RedisEmailAuthDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/redis/RedisEmailAuthDto.java
@@ -1,0 +1,28 @@
+package com.fanfixiv.auth.dto.redis;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Id;
+
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@Setter
+@RedisHash(value = "email", timeToLive= 60 * 60)
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RedisEmailAuthDto {
+  @Id
+  private String uuid;
+  private String email;
+  private String number;
+  private boolean success;
+  private LocalDateTime expireTime;
+}

--- a/src/main/java/com/fanfixiv/auth/dto/redis/RedisEmailAuthDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/redis/RedisEmailAuthDto.java
@@ -8,13 +8,12 @@ import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.Id;
-
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @Getter
 @Setter
-@RedisHash(value = "email", timeToLive= 60 * 60)
+@RedisHash(value = "email", timeToLive = 60 * 60)
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/fanfixiv/auth/dto/register/DoubleCheckDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/DoubleCheckDto.java
@@ -6,5 +6,5 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class DoubleCheckDto {
-  private boolean isDouble;
+  private boolean can_use;
 }

--- a/src/main/java/com/fanfixiv/auth/dto/register/RegisterDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/RegisterDto.java
@@ -1,6 +1,5 @@
 package com.fanfixiv.auth.dto.register;
 
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 
 import lombok.AllArgsConstructor;
@@ -11,8 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RegisterDto {
-  @Email @NotEmpty private String email;
-
   @NotEmpty private String pw;
 
   @NotEmpty private String nickname;

--- a/src/main/java/com/fanfixiv/auth/repository/RedisEmailRepository.java
+++ b/src/main/java/com/fanfixiv/auth/repository/RedisEmailRepository.java
@@ -1,0 +1,8 @@
+package com.fanfixiv.auth.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.fanfixiv.auth.dto.redis.RedisEmailAuthDto;
+
+public interface RedisEmailRepository extends CrudRepository<RedisEmailAuthDto, String> {
+}

--- a/src/main/java/com/fanfixiv/auth/service/RegisterService.java
+++ b/src/main/java/com/fanfixiv/auth/service/RegisterService.java
@@ -1,5 +1,6 @@
 package com.fanfixiv.auth.service;
 
+import com.fanfixiv.auth.dto.redis.RedisEmailAuthDto;
 import com.fanfixiv.auth.dto.register.CertEmailResultDto;
 import com.fanfixiv.auth.dto.register.CertNumberDto;
 import com.fanfixiv.auth.dto.register.CertNumberResultDto;
@@ -10,15 +11,17 @@ import com.fanfixiv.auth.entity.ProfileEntity;
 import com.fanfixiv.auth.entity.UserEntity;
 import com.fanfixiv.auth.exception.DuplicateException;
 import com.fanfixiv.auth.repository.ProfileRepository;
+import com.fanfixiv.auth.repository.RedisEmailRepository;
 import com.fanfixiv.auth.repository.UserRepository;
 import com.fanfixiv.auth.utils.RandomProvider;
 import com.fanfixiv.auth.utils.TimeProvider;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -28,29 +31,33 @@ public class RegisterService {
 
   @Autowired private UserRepository userRepository;
 
-  @Autowired private RedisTemplate<String, String> redisTemplate;
+  @Autowired private RedisEmailRepository redisEmailRepository;
 
   @Autowired private MailService mailService;
 
   @Autowired private BCryptPasswordEncoder passwordEncoder;
 
   public RegisterResultDto register(RegisterDto dto) {
-    if (userRepository.existsByEmail(dto.getEmail())) {
-      throw new DuplicateException("이미 사용중인 이메일입니다.");
-    }
     if (profileRepository.existsByNickname(dto.getNickname())) {
       throw new DuplicateException("이미 사용중인 닉네임입니다.");
     }
-    String success = redisTemplate.opsForValue().get(dto.getUuid());
-    if (success == null || !"success".equals(success)) {
-      throw new DuplicateException("본인인증이 되어있지 않습니다.");
+
+    Optional<RedisEmailAuthDto> _redisDto = redisEmailRepository.findById(dto.getUuid());
+    _redisDto.orElseThrow(() -> new DuplicateException("본인인증이 되어있지 않습니다."));
+    RedisEmailAuthDto redisDto = _redisDto.get();
+
+    if (userRepository.existsByEmail(redisDto.getEmail())) {
+      throw new DuplicateException("이미 사용중인 이메일입니다.");
+    }
+    if (redisDto.isSuccess()) {
+      new DuplicateException("본인인증이 되어있지 않습니다.");
     }
 
     ProfileEntity profile =
         ProfileEntity.builder().nickname(dto.getNickname()).is_tr(false).build();
 
     UserEntity user =
-        UserEntity.builder().email(dto.getEmail()).pw(dto.getPw()).profile(profile).build();
+        UserEntity.builder().email(redisDto.getEmail()).pw(dto.getPw()).profile(profile).build();
 
     user.hashPassword(passwordEncoder);
 
@@ -81,28 +88,34 @@ public class RegisterService {
 
     mailService.sendMail("회원가입 이메일", number, sendTo);
 
-    ValueOperations<String, String> vo = redisTemplate.opsForValue();
-    vo.set(uuid, number);
-    redisTemplate.expireAt(uuid, java.sql.Timestamp.valueOf(expireTime));
+    RedisEmailAuthDto rDto = RedisEmailAuthDto.builder()
+    .uuid(uuid)
+    .email(email)
+    .number(number)
+    .expireTime(expireTime)
+    .build();
+
+    redisEmailRepository.save(rDto);
 
     return new CertEmailResultDto(uuid, expireTime);
   }
 
   public CertNumberResultDto certNumber(CertNumberDto dto) {
-    String number = redisTemplate.opsForValue().get(dto.getUuid());
+    Optional<RedisEmailAuthDto> redisDtoOptional = redisEmailRepository.findById(dto.getUuid());
 
-    if (number == null) {
-      return new CertNumberResultDto(false);
+    if(redisDtoOptional.isPresent()) {
+      RedisEmailAuthDto redisDto = redisDtoOptional.get();
+      String number = redisDto.getNumber();      
+      LocalDateTime expire = redisDto.getExpireTime();
+  
+      if(number.equals(dto.getNumber()) && expire.isAfter(LocalDateTime.now())) {
+        redisDto.setSuccess(true);
+        redisEmailRepository.save(redisDto);
+        return new CertNumberResultDto(true);
+      }
     }
 
-    boolean result = number.equals(dto.getNumber());
 
-    if (result) {
-      this.redisTemplate.opsForValue().set(dto.getUuid(), "success");
-      this.redisTemplate.expireAt(
-          dto.getUuid(), java.sql.Timestamp.valueOf(TimeProvider.getTimeAfter1hour()));
-    }
-
-    return new CertNumberResultDto(result);
+    return new CertNumberResultDto(false);
   }
 }

--- a/src/main/java/com/fanfixiv/auth/service/RegisterService.java
+++ b/src/main/java/com/fanfixiv/auth/service/RegisterService.java
@@ -67,7 +67,7 @@ public class RegisterService {
   }
 
   public DoubleCheckDto checkNickDouble(String nickname) {
-    return new DoubleCheckDto(profileRepository.existsByNickname(nickname));
+    return new DoubleCheckDto(!profileRepository.existsByNickname(nickname));
   }
 
   public CertEmailResultDto certEmail(String email) {


### PR DESCRIPTION
> https://github.com/GiveUsMoney/FanFixiv-auth/issues/21 참고

미인증된 아이디로 회원가입이 가능하던 버그가 존재했고 수정하였습니다.

**추가한 기능**
- [x] 미인증된 아이디로 화원가입이 가능하던 버그 수정
- [x] /register/cert-nick 결과값 직관성 수정 (double -> can_use)