### PR TITLE
테스트 환경 세팅 (DB 연결 관련)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,16 +17,6 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-      AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
-      SECRET: ${{ secrets.SECRET }}
-      DB_HOST: ${{ secrets.DB_HOST }}
-      DB_PORT: ${{ secrets.DB_PORT }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      DB_PW: ${{ secrets.DB_PW }}
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17
@@ -47,3 +37,7 @@ jobs:
           arguments: |
             test
             -i
+        env:
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          SECRET: ${{ secrets.SECRET }}

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
   testImplementation 'org.springframework.security:spring-security-test'
+  testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
 	testImplementation 'io.rest-assured:rest-assured'
 
 }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -16,15 +16,21 @@ spring.redis.port=6379
 jwt.secret=${SECRET}
 jwt.tokenvalidtime=1800000
 
-# postgres db setting
-spring.datasource.url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
-spring.datasource.username=${DB_USER}
-spring.datasource.password=${DB_PW}
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+# h2 db setting
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+spring.datasource.url=jdbc:h2:~/test;
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+
 
 # hibernate setting
-spring.jpa.properties.hibernate.use_sql_comments=false
-spring.jpa.properties.hibernate.format_sql=false
-spring.jpa.properties.hibernate.show_sql=false
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.use_sql_comments=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.generate-ddl=true

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -2,12 +2,10 @@ spring.devtools.add-properties=false
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 
 # aws ses
-
 aws.ses.access-key=${AWS_ACCESS_KEY}
 aws.ses.secret-key=${AWS_SECRET_KEY}
 
 # redis
-
 spring.redis.host=127.0.0.1
 spring.redis.password=
 spring.redis.port=6379

--- a/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
@@ -4,14 +4,19 @@ import static io.restassured.RestAssured.*;
 // import static io.restassured.matcher.RestAssuredMatchers.*;
 import static org.hamcrest.Matchers.*;
 
+import com.fanfixiv.auth.entity.ProfileEntity;
+import com.fanfixiv.auth.repository.ProfileRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AuthE2ETests {
+
+  @Autowired private ProfileRepository ProfileRepository;
 
   @LocalServerPort private int _port;
 
@@ -29,5 +34,13 @@ public class AuthE2ETests {
         .assertThat()
         .body("content", equalTo("Hello World!!!"))
         .body("id", equalTo(0));
+  }
+
+  @Test
+  @DisplayName("H2 데이터 베이스 테스트")
+  void h2test() {
+    ProfileEntity profile = ProfileEntity.builder().nickname("테스트").descript("테스트입니다.").build();
+
+    ProfileRepository.save(profile);
   }
 }

--- a/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
@@ -6,6 +6,9 @@ import static org.hamcrest.Matchers.*;
 
 import com.fanfixiv.auth.entity.ProfileEntity;
 import com.fanfixiv.auth.repository.ProfileRepository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +19,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AuthE2ETests {
 
-  @Autowired private ProfileRepository ProfileRepository;
+  @Autowired private ProfileRepository profileRepository;
 
   @LocalServerPort private int _port;
 
@@ -39,8 +42,12 @@ public class AuthE2ETests {
   @Test
   @DisplayName("H2 데이터 베이스 테스트")
   void h2test() {
-    ProfileEntity profile = ProfileEntity.builder().nickname("테스트").descript("테스트입니다.").build();
+    ProfileEntity _p = ProfileEntity.builder().nickname("테스트").descript("테스트입니다.").build();
 
-    ProfileRepository.save(profile);
+    profileRepository.save(_p);
+
+    ProfileEntity p = profileRepository.findAll().get(0);
+
+    assertEquals(_p.getNickname(), p.getNickname()); 
   }
 }


### PR DESCRIPTION
> https://github.com/GiveUsMoney/FanFixiv-auth/issues/13 참고

DB를 기존의 AWS 개발 DB가 아닌 h2 내장 DB를 사용합니다.

**추가한 기능**
- [x] Github Secret 등록
- [x] h2 DB 환경 세팅
- [x] 테스트시 h2 연결 로직 설정